### PR TITLE
Fix `JavaStubifier` configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -177,6 +177,7 @@ tasks.register('includeJSpecifyJDK')  {
                 include specFile.substring(srcPrefixSize)
             }
         }
+        println("Classpath: " + sourceSets.main.runtimeClasspath.join("\n"))
         injected.execOps.javaexec {
             classpath = sourceSets.main.runtimeClasspath
             standardOutput = System.out


### PR DESCRIPTION
`main-eisop` CI fails with

````
> Task :compileJava
> Task :checker-framework:checker:checkerJar
> Task :checker-framework:checker:jar SKIPPED
Error: Could not find or load main class org.checkerframework.framework.stubifier.JavaStubifier

Caused by: java.lang.ClassNotFoundException: org.checkerframework.framework.stubifier.JavaStubifier
> Task :includeJSpecifyJDK

> Task :includeJSpecifyJDK FAILED
````

This branch simply outputs the classpath and doesn't run into this problem.

I can't reproduce the failure locally, unfortunately.