### PR TITLE
Give JavaStubifier the annotated-jdk root

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -157,9 +157,16 @@ tasks.withType(JavaCompile).configureEach {
 
 tasks.register('copyJSpecifyJDK', Copy) {
     def srcDir = "${jspecifyJdkHome}/src"
-    // This directory needs to be stored at the top-level of the resulting .jar file.
+    // The annotated JDK is laid out as an "annotated-jdk" directory containing "src", and
+    // "annotated-jdk" needs to be stored at the top level of the resulting .jar file.
     // org.checkerframework.framework.stub.AnnotationFileElementTypes will then load
     // the JDK classes from here instead of from checker.jar.
+    //
+    // It loads them from the binary stub file that includeJSpecifyJDK generates, rather than by
+    // parsing the sources under "src". That file belongs at the root of the annotated JDK, as
+    // "annotated-jdk/annotated-jdk.bin.gz" -- a sibling of "src", the layout checker.jar itself
+    // uses, and where AnnotationFileElementTypes looks for it. It is not part of the JDK sources,
+    // so it does not belong under "src"; see includeJSpecifyJDK, which writes it.
     def dstDir = "${buildDir}/generated/resources/annotated-jdk/src/"
 
     inputs.dir file(srcDir)
@@ -195,11 +202,15 @@ tasks.register('includeJSpecifyJDK', JavaExec)  {
     }
     dependsOn 'copyJSpecifyJDK'
 
+    // Give JavaStubifier the root of the annotated JDK, not the "src" directory below it that
+    // copyJSpecifyJDK fills in: JavaStubifier minimizes every .java file under the directory it is
+    // given (so the JDK sources under "src" are still minimized), and writes the binary stub file
+    // into that same directory, which is where it belongs.
     // See comment in copyJSpecifyJDK.
-    def dstDir = "${buildDir}/generated/resources/annotated-jdk/src/"
+    def jdkRootDir = "${buildDir}/generated/resources/annotated-jdk"
 
-    inputs.dir file(dstDir)
-    outputs.dir file(dstDir)
+    inputs.dir file(jdkRootDir)
+    outputs.dir file(jdkRootDir)
 
     // We only need the CF on the classpath.
     classpath = configurations.checkerFrameworkRuntimeClasspath
@@ -208,7 +219,7 @@ tasks.register('includeJSpecifyJDK', JavaExec)  {
     errorOutput = System.err
 
     mainClass = 'org.checkerframework.framework.stubifier.JavaStubifier'
-    args dstDir
+    args jdkRootDir
 }
 
 processResources.dependsOn(includeJSpecifyJDK)


### PR DESCRIPTION
..., so the binary stub lands where it belongs

includeJSpecifyJDK passed ${buildDir}/generated/resources/annotated-jdk/src/ to JavaStubifier.  JavaStubifier writes the binary stub file it generates into the directory it is given, so the binary stub landed inside the JDK source tree, as annotated-jdk/src/annotated-jdk.bin.gz.  Two consequences:

- It is a stray non-source file in a directory that otherwise holds only the JDK's .java files.
- The Checker Framework looks for the binary stub file at the root of the annotated JDK, as annotated-jdk/annotated-jdk.bin.gz -- a sibling of src, the layout checker.jar itself uses.  One directory lower, it was never found, so this JDK was text-parsed on every compilation instead of being read from its binary stub.

Pass the annotated-jdk root instead.  JavaStubifier minimizes every .java file under the directory it is given, so the JDK sources under src are still minimized, and the binary stub file is now written where the Checker Framework looks for it.  The description of the layout stays in copyJSpecifyJDK, which includeJSpecifyJDK already points at; it now also covers the binary stub file.

Requires a Checker Framework that resolves the binary stub file within the jar that supplies the annotated JDK; before that, this jar's own annotated JDK could be paired with checker.jar's binary stub file, which describes a different annotated JDK.

Related to work in https://github.com/eisop/checker-framework/pull/1853