### PR TITLE
Check that the annotated JDK's binary stub file agrees with its sources

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,14 +56,14 @@ jobs:
       - name: Build and Test (EISOP release)
         if: ${{ env.EISOP_RELEASE == 'true' }}
         # If a released CF is needed, use the following:
-        run: ./gradlew build conformanceTests demoTest --include-build ../jspecify --warning-mode all
+        run: ./gradlew build conformanceTests demoTest binaryStubDiffTest --include-build ../jspecify --warning-mode all
         env:
           SHALLOW: 1
           JSPECIFY_CONFORMANCE_TEST_MODE: details
       - name: Build and Test (EISOP build)
         if: ${{ env.EISOP_RELEASE != 'true' }}
         # If a cloned EISOP CF is needed, use the following:
-        run: ./gradlew build conformanceTests demoTest --include-build ../jspecify --include-build ../checker-framework --warning-mode all --no-configuration-cache
+        run: ./gradlew build conformanceTests demoTest binaryStubDiffTest --include-build ../jspecify --include-build ../checker-framework --warning-mode all --no-configuration-cache
         env:
           SHALLOW: 1
           JSPECIFY_CONFORMANCE_TEST_MODE: details

--- a/build.gradle
+++ b/build.gradle
@@ -115,6 +115,17 @@ configurations {
         canBeConsumed = false
         extendsFrom implementation
     }
+
+    // BinaryStubDiffChecker, for the binaryStubDiffTest task below. It is in checker-framework's
+    // framework-test artifact, which is not otherwise needed on this project's own classpaths.
+    binaryStubDiffChecker {
+        canBeResolved = true
+        canBeConsumed = false
+    }
+}
+
+dependencies {
+    binaryStubDiffChecker libs.checkerFramework.framework.test
 }
 
 // If built with `--include-build path/to/checker-framework` then
@@ -223,6 +234,65 @@ tasks.register('includeJSpecifyJDK', JavaExec)  {
 }
 
 processResources.dependsOn(includeJSpecifyJDK)
+
+// Checks that reading this project's annotated JDK from its binary stub file produces exactly the
+// annotations that parsing the JDK sources produces. The Checker Framework generates the binary
+// stub file at build time (see includeJSpecifyJDK) and reads it in preference to the sources, so a
+// disagreement between the two would silently change what the checker sees.
+//
+// The check runs while the checker initializes, over every class in the binary stub file, so what
+// is compiled here does not matter; TriggerBinaryStubDiff.java exists only to make the checker run.
+// BinaryStubDiffChecker implements it and ships in checker-framework's framework-test artifact.
+tasks.register('binaryStubDiffTest', JavaCompile) {
+    description = 'Check that the annotated JDK\'s binary stub file agrees with its sources.'
+    group = 'verification'
+    dependsOn 'jar'
+
+    source = files("${projectDir}/tests/binary-stub-diff/TriggerBinaryStubDiff.java")
+    destinationDirectory = layout.buildDirectory.dir('binaryStubDiff')
+
+    // The checker's own qualifiers (com.google.jspecify.nullness.*) must be on the compilation
+    // classpath, not merely the annotation-processor path: AnnotationBuilder resolves them through
+    // Elements.getTypeElement, which reads the compilation classpath.
+    classpath = files(tasks.jar.archiveFile) + configurations.runtimeClasspath
+
+    // The checker itself, its annotated JDK (in the jar built above), and BinaryStubDiffChecker.
+    options.annotationProcessorPath =
+            files(tasks.jar.archiveFile) +
+            configurations.runtimeClasspath +
+            configurations.binaryStubDiffChecker
+
+    // The Error Prone plugin decorates every JavaCompile task; this one runs only the checker.
+    options.errorprone.enabled = false
+
+    // Compile against the running JDK, not this project's sourceCompatibility. The check compares
+    // what the binary stub file and the JDK sources say about JDK elements, and the text parser
+    // resolves those elements against the compilation's JDK: under an older --release, an element
+    // that JDK does not have resolves to nothing, and its annotations look like they are "only in
+    // binary" when in truth neither side was ever asked about them.
+    sourceCompatibility = JavaVersion.current().majorVersion
+    targetCompatibility = JavaVersion.current().majorVersion
+
+    options.compilerArgs += [
+        '-processor',
+        'com.google.jspecify.nullness.NullSpecChecker',
+        '-AbinaryStubDiffCheck',
+        '-proc:only',
+    ]
+    options.fork = true
+    options.forkOptions.jvmArgs += [
+        'api',
+        'code',
+        'comp',
+        'file',
+        'main',
+        'model',
+        'processing',
+        'tree',
+        'util',
+    ].collect { "--add-exports=jdk.compiler/com.sun.tools.javac.${it}=ALL-UNNAMED".toString() }
+}
+
 
 tasks.withType(Test).configureEach {
     if (!JavaVersion.current().java9Compatible) {

--- a/tests/binary-stub-diff/TriggerBinaryStubDiff.java
+++ b/tests/binary-stub-diff/TriggerBinaryStubDiff.java
@@ -1,0 +1,6 @@
+// The binary-stub differential check runs once, while the checker initializes: for every class in
+// the annotated JDK's binary stub file, it compares the annotations the binary produces against the
+// ones the text parser produces from the JDK sources beside it, and reports any disagreement as an
+// error. What is compiled here is therefore irrelevant -- this file exists only to make the checker
+// run. See the binaryStubDiffTest task in build.gradle.
+class TriggerBinaryStubDiff {}


### PR DESCRIPTION
Follow-up to https://github.com/eisop/checker-framework/pull/1853 , but needs to wait until there has been an EISOP CF release.

The EISOP Checker Framework generates a binary stub file for this project's annotated JDK at build time (see includeJSpecifyJDK) and reads it in preference to the JDK sources.  Nothing checked that the two agree, and they did not: the differential check reported five records that the binary had and the text parse did not, a EISOP Checker Framework bug in parsing a record nested in another type, which its own annotated JDK does not contain and so had never exposed.

Add a binaryStubDiffTest task that runs the check.  It compiles one throwaway file with the checker and -AbinaryStubDiffCheck: the check runs while the checker initializes, over every class in the binary stub file, so what is compiled does not matter.  BinaryStubDiffChecker implements the check and ships in the EISOP Checker Framework's framework-test artifact.

Three things the task needs, none of them obvious:

- Error Prone is disabled for it.  The plugin decorates every JavaCompile task, and this one runs only the checker.
- The checker's own qualifiers must be on the compilation classpath, not just the annotation-processor path: AnnotationBuilder resolves them through Elements.getTypeElement, which reads the compilation classpath.
- It compiles against the running JDK, not this project's sourceCompatibility. The text parser resolves JDK elements against the compilation's JDK, so under an older --release an element that JDK lacks resolves to nothing and its annotations look like they are "only in binary" -- 116 phantom mismatches, all of them an artifact of the release level.